### PR TITLE
Add duration parsing

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,11 +12,12 @@ Download google credentials json from Google console.
 ```
 >>> from scheduler_agent import SchedulerAgent
 >>> agent = SchedulerAgent()
->>> agent.schedule("Set a sync call with Sarah tomorrow at 2pm")
+>>> agent.schedule("Set a sync call with Sarah tomorrow at 2pm for 45 minutes")
 "📝 Simulated: 'Sync call with Sarah' at 2024-05-22 02:00 PM UTC"
 ```
 
 The agent now composes event titles in the form `"<title> with <person>"`.
+Specify a duration with phrases like `for 45 minutes`. If omitted, events last 30 minutes by default.
 Install dependencies using pip:
 
 ```

--- a/cli.py
+++ b/cli.py
@@ -13,5 +13,6 @@ def main():
             break
         print(agent.schedule(txt))
 
+
 if __name__ == '__main__':
     main()

--- a/parser/gpt_parser.py
+++ b/parser/gpt_parser.py
@@ -15,7 +15,11 @@ class GPTParser(BaseParser):
         if not self.client:
             raise RuntimeError("OpenAI client not configured")
         today = datetime.now(pytz.timezone(Config.TIMEZONE)).strftime('%Y-%m-%d')
-        prompt = f"Assume today's date is {today}. Extract meeting details from: '{text}'. Output only JSON with keys: title, person, datetime."
+        prompt = (
+            f"Assume today's date is {today}. Extract meeting details from: '{text}'. "
+            "Output only JSON with keys: title, person, datetime, duration. "
+            "Duration should be in minutes if provided; default to 30."
+        )
         response = self.client.chat.completions.create(
             model='gpt-4o-mini',
             messages=[
@@ -28,4 +32,5 @@ class GPTParser(BaseParser):
         clean = re.sub(r'^```(?:json)?|```$', '', raw.strip())
         data = json.loads(clean)
         dt = date_parser.parse(data['datetime'])
-        return data['title'], data.get('person', 'Unnamed'), dt, 30
+        duration = int(data.get('duration', 30))
+        return data['title'], data.get('person', 'Unnamed'), dt, duration

--- a/parser/regex_parser.py
+++ b/parser/regex_parser.py
@@ -3,8 +3,15 @@ from dateutil import parser as date_parser
 from config import Config
 from parser.base_parser import BaseParser
 
+
 class RegexParser(BaseParser):
-    PATTERN = re.compile(r"(?i)set a ([\w:/\+\- ]+) (?:meeting|call|appointment)(?: with ([^@\d\n]+))?(?: on | at )?(.*?)$")
+    PATTERN = re.compile(
+        r"(?i)set a ([\w:/\+\- ]+) (?:meeting|call|appointment)"
+        r"(?: with ([A-Za-z]+))?"
+        r"(?: on | at )?(.*?)"
+        r"(?: for (\d+)\s*(?:minutes?|mins?|hours?|hrs?|hr))?"
+        r"$"
+    )
 
     def parse(self, text: str):
         m = self.PATTERN.search(text)
@@ -14,5 +21,7 @@ class RegexParser(BaseParser):
         person_raw = m.group(2)
         person = Config.KNOWN_CONTACTS.get(person_raw.lower(), person_raw.title()) if person_raw else 'Unnamed'
         time_text = m.group(3)
+        duration_raw = m.group(4)
         dt = date_parser.parse(time_text, fuzzy=True)
-        return title_prefix, person, dt, 30
+        duration = int(duration_raw) if duration_raw else 30
+        return title_prefix, person, dt, duration


### PR DESCRIPTION
## Summary
- parse duration in GPT and regex parsers
- support duration in MeetingSchedulerAgent
- document duration option in README
- fix CLI and parser files damaged earlier

## Testing
- `python -m pip install -r requirements.txt`
- `python - <<'PY'
from scheduler_agent import SchedulerAgent
agent = SchedulerAgent()
print(agent.schedule('Set a sync call with Sarah tomorrow at 2pm for 45 minutes'))
PY`

------
https://chatgpt.com/codex/tasks/task_e_68570f37bd308323b5b23f3399428eb9